### PR TITLE
For slideshow added the ability to select how to keep aspect ratio for image

### DIFF
--- a/src/rsiwidget.cpp
+++ b/src/rsiwidget.cpp
@@ -236,6 +236,7 @@ void RSIObject::readConfig()
     int slideInterval = config.readEntry( "SlideInterval", 10 );
     bool recursive =  config.readEntry( "SearchRecursiveCheck", false );
     bool showSmallImages = config.readEntry( "ShowSmallImagesCheck", true );
+    bool keepAspectRatioByExpanding = config.readEntry( "KeepAspectRatioByExpanding", true );
     QString path = config.readEntry( "ImageFolder" );
 
     bool timertype = config.readEntry( "UseNoIdleTimer", false );
@@ -252,7 +253,7 @@ void RSIObject::readConfig()
     }
     case SlideShow: {
         SlideEffect* slide = new SlideEffect( 0 );
-        slide->reset( path, recursive, showSmallImages, slideInterval );
+        slide->reset( path, recursive, showSmallImages, keepAspectRatioByExpanding, slideInterval );
         if ( slide->hasImages() )
             m_effect = slide;
         else {

--- a/src/setupmaximized.cpp
+++ b/src/setupmaximized.cpp
@@ -72,6 +72,7 @@ public:
     QComboBox*        effectBox;
     QSlider*          graySlider;
     QCheckBox* showSmallImagesCheck;
+    QCheckBox* keepAspectRatioByExpanding;
 };
 
 SetupMaximized::SetupMaximized( QWidget* parent )
@@ -177,6 +178,8 @@ SetupMaximized::SetupMaximized( QWidget* parent )
             this );
     d->showSmallImagesCheck = new QCheckBox( i18n( "Show small images" ),
             this );
+    d->keepAspectRatioByExpanding = new QCheckBox ( i18n( "Keep aspect ratio by expanding" ),
+            this );
 
     QWidget *m5 = new QWidget( this );
     QHBoxLayout *m5HBoxLayout = new QHBoxLayout(m5);
@@ -198,6 +201,7 @@ SetupMaximized::SetupMaximized( QWidget* parent )
     vboxg->addWidget( imageFolderBox );
     vboxg->addWidget( d->searchRecursiveCheck );
     vboxg->addWidget( d->showSmallImagesCheck );
+    vboxg->addWidget( d->keepAspectRatioByExpanding );
     vboxg->addWidget( m5 );
     d->slideshowBox->setLayout( vboxg );
 
@@ -343,6 +347,8 @@ void SetupMaximized::applySettings()
                        d->searchRecursiveCheck->isChecked() );
     config.writeEntry( "ShowSmallImagesCheck",
                        d->showSmallImagesCheck->isChecked() );
+    config.writeEntry( "KeepAspectRatioByExpanding",
+                       d->keepAspectRatioByExpanding->isChecked() );
     config.writeEntry( "Effect",
                        d->effectBox->itemData( d->effectBox->currentIndex() ) );
 
@@ -386,6 +392,8 @@ void SetupMaximized::readSettings()
         config.readEntry( "SearchRecursiveCheck", false ) );
     d->showSmallImagesCheck->setChecked(
         config.readEntry( "ShowSmallImagesCheck", true ) );
+    d->keepAspectRatioByExpanding->setChecked(
+        config.readEntry( "KeepAspectRatioByExpanding", true ) );
     d->disableAccel->setChecked( config.readEntry( "DisableAccel", false ) );
     d->readOnlyPlasma->setChecked(
         config.readEntry( "UsePlasmaReadOnly", true ) );

--- a/src/slideshoweffect.cpp
+++ b/src/slideshoweffect.cpp
@@ -25,6 +25,8 @@
 #include <QDesktopWidget>
 #include <QDir>
 #include <QTimer>
+#include <QVBoxLayout>
+#include <QLabel>
 
 #include <KWindowSystem>
 
@@ -125,13 +127,16 @@ void SlideEffect::loadImage()
         }
     }
 
-    QImage m( image.scaled( size.width(), size.height(), Qt::KeepAspectRatioByExpanding ) );
+    Qt::AspectRatioMode mode = ( m_keepAspectRatioByExpanding ) ? Qt::KeepAspectRatioByExpanding
+                                                                : Qt::KeepAspectRatio;
+    QImage m( image.scaled( size.width(), size.height(), mode ) );
 
     if ( m.isNull() )
         return;
 
     m_slidewidget->setImage( m );
 }
+
 
 void SlideEffect::findImagesInFolder( const QString& folder )
 {
@@ -176,7 +181,7 @@ void SlideEffect::slotNewSlide()
     loadImage();
 }
 
-void SlideEffect::reset( const QString& path, bool recursive, bool showSmallImages, int slideInterval )
+void SlideEffect::reset( const QString& path, bool recursive, bool showSmallImages, bool keepAspectRatioByExpanding, int slideInterval )
 {
     m_files.clear();
     m_files_done.clear();
@@ -184,6 +189,7 @@ void SlideEffect::reset( const QString& path, bool recursive, bool showSmallImag
     m_searchRecursive = recursive;
     m_showSmallImages = showSmallImages;
     m_slideInterval = slideInterval;
+    m_keepAspectRatioByExpanding = keepAspectRatioByExpanding;
 
     findImagesInFolder( path );
     qDebug() << "Amount of Files:" << m_files.count();
@@ -198,6 +204,15 @@ SlideWidget::SlideWidget( QWidget *parent )
 {
     slotDimension();
     connect( QApplication::desktop(), &QDesktopWidget::screenCountChanged, this, &SlideWidget::slotDimension );
+
+    QVBoxLayout *boxLayout = new QVBoxLayout( this );
+    boxLayout->setSpacing(0);
+    boxLayout->setContentsMargins(0, 0, 0, 0);
+    setLayout( boxLayout );
+    imageLabel = new QLabel();
+    imageLabel->setMaximumSize( width(), height() );
+    imageLabel->setAlignment( Qt::AlignCenter );
+    layout()->addWidget(imageLabel);
 }
 
 SlideWidget::~SlideWidget() {}
@@ -211,7 +226,5 @@ void SlideWidget::slotDimension()
 
 void SlideWidget::setImage( const QImage &image )
 {
-    QPalette palette;
-    palette.setBrush( backgroundRole(), QBrush( QPixmap::fromImage( image ) ) );
-    setPalette( palette );
+    imageLabel->setPixmap( QPixmap::fromImage(image) );
 }

--- a/src/slideshoweffect.h
+++ b/src/slideshoweffect.h
@@ -25,6 +25,7 @@
 #include "breakbase.h"
 
 class SlideWidget;
+class QLabel;
 
 class SlideEffect : public BreakBase
 {
@@ -33,7 +34,7 @@ class SlideEffect : public BreakBase
 public:
     SlideEffect( QObject *parent );
     ~SlideEffect();
-    void reset( const QString& path, bool recursive, bool showSmallImages, int interval );
+    void reset( const QString& path, bool recursive, bool showSmallImages, bool keepAspectRatioByExpanding, int interval );
     void activate() override;
     void deactivate() override;
     bool hasImages();
@@ -52,6 +53,7 @@ private:
 
     bool            m_searchRecursive;
     bool            m_showSmallImages;
+    bool            m_keepAspectRatioByExpanding;
     int             m_slideInterval;
 
     QStringList     m_files;
@@ -78,6 +80,10 @@ public:
 
 private slots:
     void slotDimension();
+
+private:
+    QLabel *imageLabel;
+
 };
 
 #   endif


### PR DESCRIPTION
It's allow to reduce the images so that they fit completely on the screen during the slide show. And if mode "Keep aspect ratio by expanding" is selected, the central part of the image is displayed now.