### PR TITLE
Adding a global shortcut for suspending/resume rsibreak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(KF5 REQUIRED COMPONENTS
     TextWidgets
     XmlGui
     WindowSystem
+    GlobalAccel
     )
 
 include(KDEInstallDirs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(rsibreak_lib
     KF5::TextWidgets
     KF5::XmlGui
     KF5::WindowSystem
+    KF5::GlobalAccel
     Qt5::DBus
 )
 target_link_libraries(rsibreak rsibreak_lib)

--- a/src/rsidock.cpp
+++ b/src/rsidock.cpp
@@ -31,6 +31,7 @@
 #include <KAboutData>
 #include <KLocalizedString>
 #include <KIconLoader>
+#include <KGlobalAccel>
 #include <QMenu>
 #include <KNotifyConfigWidget>
 #include <KHelpMenu>
@@ -83,6 +84,10 @@ RSIDock::RSIDock( QObject *parent )
 
     menu->addSeparator();
     m_suspendItem = doAddAction(menu, SmallIcon( "media-playback-pause" ), i18n( "&Suspend RSIBreak" ), this, &RSIDock::slotToggleSuspend );
+    QString suspendName = aboutData.displayName() + "suspend-resume";
+    m_suspendItem->setObjectName( suspendName );
+    KGlobalAccel::setGlobalShortcut( m_suspendItem, QKeySequence( Qt::META + Qt::SHIFT + Qt::Key_S ) );
+
     doAddAction(menu, SmallIcon( "view-statistics" ), i18n( "&Usage Statistics" ), this, &RSIDock::slotShowStatistics );
     doAddAction(menu, SmallIcon( "preferences-desktop-notification" ), i18n( "Configure &Notifications..." ), this, &RSIDock::slotConfigureNotifications );
     doAddAction(menu, QIcon::fromTheme( "configure" ), i18n( "&Configure RSIBreak..." ), this, &RSIDock::slotConfigure );


### PR DESCRIPTION
This fixes a wishlist issue in the KDE bug tracker : https://bugs.kde.org/show_bug.cgi?id=368765

This is my first KDE request, so please feel free to give lots of feedback.